### PR TITLE
Fix config issues

### DIFF
--- a/addons/TranslationManager/Exporting/Exporter.php
+++ b/addons/TranslationManager/Exporting/Exporter.php
@@ -40,11 +40,11 @@ class Exporter
 
     protected function parseConfig($config)
     {
-        if (is_string($this->config['exclude_page_ids'])) {
+        if (is_string($config['exclude_page_ids'])) {
             $config['exclude_page_ids'] = explode(',', $config['exclude_page_ids']);
         }
 
-        if (is_string($this->config['exclude_collection_slugs'])) {
+        if (is_string($config['exclude_collection_slugs'])) {
             $config['exclude_collection_slugs'] = explode(',', $config['exclude_collection_slugs']);
         }
 

--- a/addons/TranslationManager/default.yaml
+++ b/addons/TranslationManager/default.yaml
@@ -1,0 +1,4 @@
+page_url: ''
+page_query_string: ''
+exclude_page_ids: ''
+exclude_collection_slugs: ''


### PR DESCRIPTION
Hi @mattias-persson, thanks for building this addon! Tried giving it a run today and ran into some issues after installation: 

Firstly, the `parseConfig` method tries calling `$this->config['exclude_page_ids']` which doesn't exist yet (since this method returns the config). And second, there wasn't a `default.yaml` settings file which is needed for Statamic to fallback on (i.e. when the user hasn't saved/made changes to the addon's settings in the CP).

After fixing these I was able to get the export working.  Let me know if you have any questions/concerns!