### PR TITLE
Flatten sections into simple 'fields' array

### DIFF
--- a/addons/TranslationManager/Helpers/Field.php
+++ b/addons/TranslationManager/Helpers/Field.php
@@ -101,10 +101,12 @@ class Field
         // Arrays are formatted as field.index. We only want the field name.
         $field = explode('.', $field)[0];
 
-        if (!empty($fieldset['fields'][$field])) {
-            return $fieldset['fields'][$field] ?? $fieldset['fields'][$field];
-        } elseif (!empty($fieldset['sections']['main']['fields'][$field])) {
-            return $fieldset['sections']['main']['fields'][$field] ?? $fieldset['sections']['main']['fields'][$field];
+        if (isset($fieldset['sections'])) {
+            $fieldset['fields'] = collect($fieldset['sections'])->flatMap(function ($section) {
+                return $section['fields'] ?? [];
+            })->toArray();
         }
+
+        return $fieldset['fields'][$field] ?? null;
     }
 }


### PR DESCRIPTION
Currently it seems sections _must_ be named `main` for the addon to read its `fields`.

This PR allows sections to be named anything and simply flattens every section into a simple, single `fields` structure (just like fieldsets that don't use sections).

Let me know if you have any questions! 