### PR TITLE
Add item slug to data if available

### DIFF
--- a/addons/TranslationManager/Exporting/Preparators/FieldPreparator.php
+++ b/addons/TranslationManager/Exporting/Preparators/FieldPreparator.php
@@ -28,7 +28,15 @@ class FieldPreparator
         // Reset the fields for each item.
         $this->fields = [];
 
-        foreach ($item->in(Locale::default())->data() as $fieldName => $value) {
+        $localizedItem = $item->in(Locale::default());
+
+        $data = $localizedItem->data();
+
+        if ($slug = @$localizedItem->slug()) {
+            $data['slug'] = $slug;
+        }
+
+        foreach ($data as $fieldName => $value) {
             $field = new Field($item, $fieldName);
 
             // Determine whether the field should be translated, or skipped.


### PR DESCRIPTION
This PR adds support for translating slugs! 

Basically, during field preparation, `slug` gets pushed to the `data` array, if it's available. Directly after this, `data` is looped over to prepare all the fields and check if they should be translated; here the `slug` will get filtered out again if the user didn't add `localizable: true` for the `slug` attribute in their fieldset:

```yaml
subtitle:
  type: text
  localizable: true
```

I initially wanted to use `method_exists` to check if  `->slug()` was available, but it kept returning `false`, I think this is due to Statamic using magic methods internally so the method may not "officially" exist on the class. As a way around this I simply suppress errors using `@` since we don't really need to act if an error is thrown here, we just want to skip the `slug` assignment in that case. If you have a better/cleaner approach, please let me know!