### PR TITLE
Fix issue if fieldset is missing a type

### DIFF
--- a/addons/TranslationManager/Helpers/Field.php
+++ b/addons/TranslationManager/Helpers/Field.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Addons\TranslationManager\Helpers;
 
+use Statamic\API\Arr;
 use Statamic\API\Fieldset;
 
 class Field
@@ -109,7 +110,7 @@ class Field
 
         // Merge 'partial' fieldtypes into fields array
         $fieldset['fields'] = collect($fieldset['fields'])->flatMap(function ($field, $key) {
-            if ($field['type'] === 'partial') {
+            if (Arr::get($field, 'type') === 'partial') {
                 return Fieldset::get($field['fieldset'])->contents()['fields'];
             }
 


### PR DESCRIPTION
Noticed an issue introduced in my earlier PR #9. 

It is _technically_ possible to leave out `type`s in fieldsets which Statamic then defaults to text fields -- this breaks the export. Apologies! 